### PR TITLE
fix(wrapper): spawn resolved core CLI; align core exports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,10 @@
       "name": "devcontainer-wizard-monorepo",
       "workspaces": [
         "packages/*"
-      ]
+      ],
+      "dependencies": {
+        "devcontainer-wizard": "^1.1.1"
+      }
     },
     "node_modules/@aws-crypto/crc32": {
       "version": "5.2.0",
@@ -4655,7 +4658,7 @@
     },
     "packages/core": {
       "name": "@theredguild/devcontainer-wizard",
-      "version": "1.0.0",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "@inquirer/core": "^10.1.15",
@@ -4677,11 +4680,11 @@
     },
     "packages/wrapper": {
       "name": "devcontainer-wizard",
-      "version": "1.0.0",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "^4.5.2",
-        "@theredguild/devcontainer-wizard": "^1.0.0"
+        "@theredguild/devcontainer-wizard": "1.1.1"
       },
       "bin": {
         "devcontainer-wizard": "bin.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,11 @@
 {
   "name": "devcontainer-wizard-monorepo",
   "private": true,
-  "workspaces": ["packages/*"],
-  "packageManager": "npm@10"
+  "workspaces": [
+    "packages/*"
+  ],
+  "packageManager": "npm@10",
+  "dependencies": {
+    "devcontainer-wizard": "^1.1.1"
+  }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -7,9 +7,10 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
-    ".": "./dist/index.js",
-    "./cli": "./dist/index.js"
-  },
+    ".": "./bin/run.js",
+    "./package.json": "./package.json",
+    "./bin/run.js": "./bin/run.js"
+  }, 
   "dependencies": {
     "@inquirer/core": "^10.1.15",
     "@inquirer/prompts": "^7.8.1",

--- a/packages/wrapper/pnpm-lock.yaml
+++ b/packages/wrapper/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^4.5.2
         version: 4.5.3
       '@theredguild/devcontainer-wizard':
-        specifier: ^1.0.0
-        version: 1.0.0
+        specifier: 1.1.0
+        version: 1.1.0
 
 packages:
 
@@ -151,9 +151,9 @@ packages:
     resolution: {integrity: sha512-ISoFlfmsuxJvNKXhabCO4/KqNXDQdLHchZdTPfZbtqAsQbqTw5IKitLVZq9Sz1LWizN37HILp4u0350B8scBjg==}
     engines: {node: '>=18.0.0'}
 
-  '@theredguild/devcontainer-wizard@1.0.0':
-    resolution: {integrity: sha512-rqV7IztMhCaOSmWHzGwCr6PwE9ZYFRDUF0kdd9dHeBu7bxwBuU401rIu+pbvm7TFDYo4PFuUGOxy7pvZlrgyEw==}
-    hasBin: true
+  '@theredguild/devcontainer-wizard@1.1.0':
+    resolution: {integrity: sha512-E3uAGzx08uIFb2A7tp4pBP+lVRdCWr/yTn17/x9f6zTzMC8Y8clGCuvvyiBlspTrwDNZ5OALY+vDgU06yJoJ8A==}
+    engines: {node: '>=18.17'}
 
   ansi-escapes@4.3.2:
     resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
@@ -464,7 +464,7 @@ snapshots:
       wordwrap: 1.0.0
       wrap-ansi: 7.0.0
 
-  '@theredguild/devcontainer-wizard@1.0.0':
+  '@theredguild/devcontainer-wizard@1.1.0':
     dependencies:
       '@inquirer/core': 10.2.0
       '@inquirer/prompts': 7.8.4


### PR DESCRIPTION
Replace oclif 'dir' execution with spawning the resolved '@theredguild/devcontainer-wizard' entry. Adds a helpful hint when resolution fails.

Align core package exports to expose './bin/run.js' and './package.json' for proper resolution by consumers.

Bump core and wrapper to 1.1.1; align wrapper dependency versions; add root dependency on 'devcontainer-wizard'.

Update lockfiles to reflect version and dependency changes.