### PR TITLE
feat: add core languages selection step to wizard

### DIFF
--- a/packages/core/src/core/scripts/generate_dev_env.ts
+++ b/packages/core/src/core/scripts/generate_dev_env.ts
@@ -45,6 +45,19 @@ export async function generateDevEnvironment(options: GenerationOptions = {}): P
   
   const requiredDeps = new Set<ToolKey>();
   
+  // Add core languages selected by user
+  config.coreLanguages?.forEach(lang => {
+    if (lang === 'rust') {
+      requiredDeps.add('rust');
+    } else if (lang === 'python') {
+      requiredDeps.add('python');
+    } else if (lang === 'go') {
+      requiredDeps.add('go');
+    } else if (lang === 'node') {
+      requiredDeps.add('node');
+    }
+  });
+  
   if (config.languages?.includes('solidity')) {
     requiredDeps.add('python');
     requiredDeps.add('solc-select');
@@ -420,6 +433,7 @@ export async function generateDevEnvironment(options: GenerationOptions = {}): P
   console.log('\n' + colorize.brand(symbols.diamond + ' Generation Summary:'));
   console.log('   Project: ' + projectName);
   console.log('   Location: ' + devcontainerDir);
+  console.log('   Core Languages: ' + (config.coreLanguages?.join(', ') || 'None'));
   console.log('   Languages: ' + (config.languages?.join(', ') || 'None'));
   console.log('   Frameworks: ' + (config.frameworks?.join(', ') || 'None'));
   console.log('   Security Tools: ' + (config.securityTooling?.join(', ') || 'None'));

--- a/packages/core/src/core/wizard/coreLanguages.ts
+++ b/packages/core/src/core/wizard/coreLanguages.ts
@@ -1,0 +1,18 @@
+import { checkboxWithTopDescription } from "@/ui/components/checkboxWithTopDescription";
+
+export async function coreLanguages(state: {coreLanguages?: string[]}) {
+  return await checkboxWithTopDescription({
+    message: 'Select core programming languages',
+    choices: [
+        { name: 'Rust', value: 'rust', description: 'Rust compiler and cargo package manager', checked: state.coreLanguages?.includes("rust") },
+        { name: 'Python', value: 'python', description: 'Python runtime with pip and uv package managers', checked: state.coreLanguages?.includes("python") },
+        { name: 'Go', value: 'go', description: 'Go programming language with asdf version manager', checked: state.coreLanguages?.includes("go") },
+        { name: 'Node.js', value: 'node', description: 'Node.js runtime with pnpm package manager', checked: state.coreLanguages?.includes("node") }
+    ],
+    footer: {
+      back: true,
+      exit: true,
+    },
+    allowBack: true,
+  });
+}

--- a/packages/core/src/core/wizard/index.ts
+++ b/packages/core/src/core/wizard/index.ts
@@ -1,3 +1,4 @@
+export { coreLanguages } from "./coreLanguages";
 export { languages } from "./languages";
 export { frameworks } from "./frameworks";
 export { fuzzingAndTesting } from "./fuzzingTesting";

--- a/packages/core/src/core/wizard/wizard.ts
+++ b/packages/core/src/core/wizard/wizard.ts
@@ -1,4 +1,5 @@
 import {
+    coreLanguages,
     languages,
     frameworks,
     fuzzingAndTesting,
@@ -26,6 +27,11 @@ export async function wizard(args: { name?: string }) {
     async () => {
         const result = args.name !== undefined ? args.name : await devcontainerName({ name: wizardState.name });
         if ((result as any) !== BACK) wizardState.name = result as string;
+        return result;
+    },
+    async () => {
+        const result = await coreLanguages({ coreLanguages: wizardState.coreLanguages });
+        if ((result as any) !== BACK) wizardState.coreLanguages = result as string[];
         return result;
     },
     async () => {

--- a/packages/core/src/types.d.ts
+++ b/packages/core/src/types.d.ts
@@ -21,6 +21,7 @@ export type Selection = {
 };
 
 export type WizardState = {
+  coreLanguages?: string[]
   languages?: string[]
   frameworks?: string[]
   fuzzingAndTesting?: string[]


### PR DESCRIPTION
Add new wizard step allowing users to directly select core programming languages (Rust, Python, Go, Node.js) before smart contract languages.

This enables installing runtimes without requiring a tool dependency, while maintaining compatibility with automatic dependency installation.

Changes:
- Add coreLanguages.ts wizard step with checkbox UI
- Update WizardState type to include coreLanguages field
- Integrate step into wizard flow after devcontainerName
- Process core language selections in generateDevEnvironment
- Display core languages in generation summary

The selection is optional and uses a Set to prevent duplicate installations when languages are also required by selected tools.