### PR TITLE
fix(ci): build tarball filename from package.json to avoid oclif warnings

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,7 +54,10 @@ jobs:
         id: pack
         working-directory: packages/core
         run: |
-          FILENAME=$(pnpm pack --json | jq -r .filename)
+          NAME=$(jq -r .name package.json | sed 's/@//' | sed 's/\//-/g')
+          VERSION=$(jq -r .version package.json)
+          FILENAME="${NAME}-${VERSION}.tgz"
+          pnpm pack --silent
           echo "FILENAME=$FILENAME"
           echo "filename=$FILENAME" >> $GITHUB_OUTPUT
       
@@ -163,7 +166,10 @@ jobs:
         id: pack
         working-directory: packages/wrapper
         run: |
-          FILENAME=$(pnpm pack --json | jq -r .filename)
+          NAME=$(jq -r .name package.json | sed 's/@//' | sed 's/\//-/g')
+          VERSION=$(jq -r .version package.json)
+          FILENAME="${NAME}-${VERSION}.tgz"
+          pnpm pack --silent
           echo "FILENAME=$FILENAME"
           echo "filename=$FILENAME" >> $GITHUB_OUTPUT
       


### PR DESCRIPTION
The previous approach using 'pnpm pack --json | jq -r .filename' was fragile because oclif warnings would contaminate the JSON output, causing jq parsing to fail.

Now we construct the filename directly from package.json using the standard npm naming convention: <name>-<version>.tgz. This makes the workflow more robust and independent of pnpm's output format.

Changes:
- Extract name and version directly from package.json using jq
- Transform scoped package names (@org/pkg -> org-pkg)
- Construct filename following npm conventions
- Use 'pnpm pack --silent' to suppress unnecessary output